### PR TITLE
app: Move to ProtoBuf storage

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization'
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
+    id 'com.google.protobuf'
 }
 
 def getVersionCode = { ->
@@ -100,6 +101,7 @@ dependencies {
     implementation "io.ktor:ktor-client-logging:$ktor_version"
     implementation 'androidx.databinding:databinding-runtime:7.1.2'
     implementation 'androidx.datastore:datastore:1.0.0'
+    implementation 'com.google.protobuf:protobuf-javalite:3.22.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
@@ -117,4 +119,23 @@ dependencies {
 
 kapt {
     correctErrorTypes true
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.22.2"
+    }
+
+    // Generates the java Protobuf-lite code for the Protobufs in this project. See
+    // https://github.com/google/protobuf-gradle-plugin#customizing-protobuf-compilation
+    // for more information.
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                java {
+                    option 'lite'
+                }
+            }
+        }
+    }
 }

--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -93,7 +93,6 @@ dependencies {
     implementation "androidx.camera:camera-view:$camerax_version"
     implementation 'com.google.zxing:core:3.5.1'
     implementation "androidx.camera:camera-camera2:$camerax_version"
-    implementation 'androidx.datastore:datastore-preferences:1.0.0'
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-cio:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
@@ -101,7 +100,7 @@ dependencies {
     implementation "io.ktor:ktor-client-logging:$ktor_version"
     implementation 'androidx.databinding:databinding-runtime:7.1.2'
     implementation 'androidx.datastore:datastore:1.0.0'
-    implementation 'com.google.protobuf:protobuf-javalite:3.22.2'
+    implementation "com.google.protobuf:protobuf-javalite:$protobuf_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
@@ -123,7 +122,7 @@ kapt {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.22.2"
+        artifact = "com.google.protobuf:protoc:$protobuf_version"
     }
 
     // Generates the java Protobuf-lite code for the Protobufs in this project. See

--- a/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationLocalDataSource.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationLocalDataSource.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class RegistrationLocalDataSource @Inject constructor(
-    @ApplicationContext val context: Context
+    @ApplicationContext val context: Context,
+    val regStateStore: DataStore<RegistrationState>
 ) {
 
     companion object {

--- a/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationLocalDataSource.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationLocalDataSource.kt
@@ -1,43 +1,16 @@
 package de.stustanet.stustapay.storage
 
-import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import dagger.hilt.android.qualifiers.ApplicationContext
 import de.stustanet.stustapay.model.RegistrationState
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class RegistrationLocalDataSource @Inject constructor(
-    @ApplicationContext val context: Context,
-    val regStateStore: DataStore<RegistrationState>
+    private val regStateStore: DataStore<RegistrationState>
 ) {
-
-    companion object {
-        private val Context.loginStore: DataStore<Preferences> by preferencesDataStore("login")
-        private val API_ENDPOINT = stringPreferencesKey("api_endpoint")
-        private val AUTH_TOKEN = stringPreferencesKey("auth_token")
-    }
-
-    val registrationState: Flow<RegistrationState> = context.loginStore.data.map { pref ->
-        pref[AUTH_TOKEN]?.let { token ->
-            pref[API_ENDPOINT]?.let { endpoint ->
-                RegistrationState.Registered(token = token, apiUrl = endpoint, "in local storage")
-            }
-        } ?:
-        RegistrationState.Error(
-            message = "not in local storage"
-        )
-    }
+    val registrationState: Flow<RegistrationState> = regStateStore.data
 
     suspend fun setState(registrationState: RegistrationState.Registered) {
-        context.loginStore.edit { pref ->
-            pref[AUTH_TOKEN] = registrationState.token
-            pref[API_ENDPOINT] = registrationState.apiUrl
-        }
+        regStateStore.updateData { registrationState }
     }
 }

--- a/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationStateSerializer.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationStateSerializer.kt
@@ -1,0 +1,65 @@
+package de.stustanet.stustapay.storage
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.core.Serializer
+import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import de.stustanet.stustapay.model.RegistrationState
+import de.stustanet.stustapay.proto.RegistrationStateProto
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Singleton
+
+object RegistrationStateSerializer : Serializer<RegistrationState> {
+    override val defaultValue: RegistrationState
+        get() = RegistrationState.Error("not in local storage")
+
+    override suspend fun readFrom(input: InputStream): RegistrationState {
+        return try {
+            val regState = RegistrationStateProto.parseFrom(input);
+            RegistrationState.Registered(
+                regState.authToken,
+                regState.apiEndpoint,
+                "in local storage")
+        } catch (exception: InvalidProtocolBufferException) {
+            RegistrationState.Error("data in local storage corrupted")
+        }
+    }
+
+    override suspend fun writeTo(t: RegistrationState, output: OutputStream) {
+        when(t) {
+            is RegistrationState.Registered -> {
+                val regState = RegistrationStateProto.newBuilder()
+                    .setApiEndpoint(t.apiUrl)
+                    .setAuthToken(t.token)
+                    .build()
+                regState.writeTo(output);
+            }
+            else -> {
+                throw java.lang.RuntimeException("Tried to serialize invalid RegistrationState");
+            }
+        }
+    }
+}
+
+
+@InstallIn(SingletonComponent::class)
+@Module
+class RegistrationStateDataStoreModule {
+    @Singleton
+    @Provides
+    fun createRegistrationStateDataStore(@ApplicationContext context: Context): DataStore<RegistrationState> =
+        DataStoreFactory.create(
+            serializer = RegistrationStateSerializer,
+            produceFile = {
+                File("${context.cacheDir.path}/registration_state.pb")
+            }
+        )
+}

--- a/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationStateSerializer.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/storage/RegistrationStateSerializer.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.Serializer
-import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.InvalidProtocolBufferException
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/app/src/main/proto/RegistrationStateProto.proto
+++ b/app/app/src/main/proto/RegistrationStateProto.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+option java_package = "de.stustanet.stustapay.proto";
+option java_multiple_files = true;
+
+message RegistrationStateProto {
+  string apiEndpoint = 1;
+  string authToken = 2;
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,4 +11,5 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.10' apply false
     id "com.google.dagger.hilt.android" version "2.44" apply false
+    id "com.google.protobuf" version "0.9.1" apply false
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         compose_ui_version = '1.3.3'
         camerax_version = '1.2.1'
         ktor_version = '2.2.3'
+        protobuf_version = '3.22.2'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
Move away from the key-value based 'preferences DataStore' and use ProtoBuf storage instead.
(Not tested yet, but maybe it just works? :P)

Also
- not sure if throwing an exception is the right way to go when trying to serialize an invalid RegistrationState, but at least for debugging it's probably useful to know if that happens
- `RegistrationLocalDataSource` might be superfluous at this point, since it's essentially just a wrapper around the `DataStore<RegistrationState>`.