### PR TITLE
app: backend driven terminal config

### DIFF
--- a/app/app/src/main/java/de/stustanet/stustapay/model/TerminalConfigState.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/model/TerminalConfigState.kt
@@ -1,0 +1,11 @@
+package de.stustanet.stustapay.model
+
+sealed interface TerminalConfigState {
+    data class Success(
+        var config: TerminalConfig
+    ) : TerminalConfigState
+
+    data class Error(
+        val message: String
+    ) : TerminalConfigState
+}

--- a/app/app/src/main/java/de/stustanet/stustapay/net/TerminalAPI.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/net/TerminalAPI.kt
@@ -4,10 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import de.stustanet.stustapay.model.HealthStatus
-import de.stustanet.stustapay.model.NewOrder
-import de.stustanet.stustapay.model.PendingOrder
-import de.stustanet.stustapay.model.TerminalRegistrationSuccess
+import de.stustanet.stustapay.model.*
 import de.stustanet.stustapay.storage.RegistrationLocalDataSource
 import java.util.*
 import javax.inject.Singleton
@@ -67,4 +64,9 @@ interface TerminalAPI {
      * Create a new order, which is not yet booked.
      */
     suspend fun createOrder(newOrder: NewOrder): Response<PendingOrder>
+
+    /**
+     * Get the button configuration of the terminal.
+     */
+    suspend fun getTerminalConfig(): Response<TerminalConfig>
 }

--- a/app/app/src/main/java/de/stustanet/stustapay/net/TerminalHTTPAPI.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/net/TerminalHTTPAPI.kt
@@ -65,4 +65,8 @@ class TerminalHTTPAPI @Inject constructor(
     override suspend fun createOrder(newOrder: NewOrder): Response<PendingOrder> {
         return client.post("order/create") { newOrder }
     }
+
+    override suspend fun getTerminalConfig(): Response<TerminalConfig> {
+        return client.get("config")
+    }
 }

--- a/app/app/src/main/java/de/stustanet/stustapay/netsource/TerminalConfigRemoteDataSource.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/netsource/TerminalConfigRemoteDataSource.kt
@@ -1,0 +1,15 @@
+package de.stustanet.stustapay.netsource
+
+import de.stustanet.stustapay.model.TerminalConfig
+import de.stustanet.stustapay.net.Response
+import de.stustanet.stustapay.net.TerminalAPI
+import javax.inject.Inject
+
+class TerminalConfigRemoteDataSource @Inject constructor(
+    private val terminalAPI: TerminalAPI
+){
+    // TODO call the function from the TerminalConfigRepository
+    suspend fun getTerminalConfig(): Response<TerminalConfig> {
+        return terminalAPI.getTerminalConfig()
+    }
+}

--- a/app/app/src/main/java/de/stustanet/stustapay/repository/TerminalConfigRepository.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/repository/TerminalConfigRepository.kt
@@ -1,0 +1,39 @@
+package de.stustanet.stustapay.repository
+
+import de.stustanet.stustapay.model.TerminalConfig
+import de.stustanet.stustapay.model.TerminalConfigState
+import de.stustanet.stustapay.model.TillButton
+import de.stustanet.stustapay.netsource.TerminalConfigRemoteDataSource
+import de.stustanet.stustapay.ui.order.TillProductButtonUI
+import kotlinx.coroutines.flow.MutableSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TerminalConfigRepository @Inject constructor(
+    private val terminalConfigRemoteDataSource: TerminalConfigRemoteDataSource,
+) {
+    var terminalConfigState = MutableSharedFlow<TerminalConfigState>()
+
+    suspend fun fetchConfig() {
+        return terminalConfigState.emit(
+            TerminalConfigState.Success(
+                TerminalConfig(
+                    id = 0,
+                    name = "test config",
+                    description = "testing the fetch workflow",
+                    user_privileges = null,
+                    allow_top_up = false,
+                    buttons = listOf<TillButton>(
+                        TillButton(name = "Bier", product_ids = listOf(0, 10), price = 3.5, id = 0),
+                        TillButton(name = "Mass", product_ids = listOf(1, 10), price = 6.0, id = 1),
+                        TillButton(name = "Weißbier", product_ids = listOf(2, 10), price = 3.5, id = 2),
+                        TillButton(name = "Radler", product_ids = listOf(3, 10), price = 3.5, id = 3),
+                        TillButton(name = "Spezi", product_ids = listOf(4, 10), price = 3.5, id = 4),
+                        TillButton(name = "Pfand zurück", product_ids = listOf(11), price = -2.0, id = 11),
+                    )
+                ),
+            )
+        )
+    }
+}

--- a/app/app/src/main/java/de/stustanet/stustapay/ui/order/OrderSelection.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/ui/order/OrderSelection.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -23,11 +24,19 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 fun OrderSelection(
     viewModel: OrderViewModel,
     onAbort: () -> Unit,
-    onSubmit: () -> Unit
+    onSubmit: () -> Unit,
+    fetch: () -> Unit
 ) {
     val orderUiState by viewModel.orderUiState.collectAsStateWithLifecycle()
     val status by viewModel.status.collectAsStateWithLifecycle()
     val haptic = LocalHapticFeedback.current
+
+    /**
+     * Fetch Terminal Config on startup.
+     */
+    LaunchedEffect(true) {
+        fetch()
+    }
 
     Scaffold(
         topBar = {

--- a/app/app/src/main/java/de/stustanet/stustapay/ui/order/OrderView.kt
+++ b/app/app/src/main/java/de/stustanet/stustapay/ui/order/OrderView.kt
@@ -39,6 +39,11 @@ fun OrderView(viewModel: OrderViewModel = hiltViewModel()) {
                             viewModel.submitOrder()
                             //chipScanState.scan("--total cost--€\nScan a chip")
                         }
+                    },
+                    fetch = {
+                        scope.launch {
+                            viewModel.fetchConfig()
+                        }
                     }
                 )
             }


### PR DESCRIPTION
update the order view based on a terminal config
currently the terminal config is hard coded on start up the network fetch is implemented (TerminalConfigRemoteDataSource) but must be called to connect it with the backend