### PR TITLE
Bon: inverted QR code colors

### DIFF
--- a/stustapay/bon/tex/bon.tex
+++ b/stustapay/bon/tex/bon.tex
@@ -151,7 +151,8 @@
 
     \vspace{1em}
     \qrset{height=3cm}
-    \fbox{\qrcode[nolinks]{\VAR[order.tse_qr_code_text|latex]}}
+    \color{bgcolor}
+    \fcolorbox{textcolor}{textcolor}{\qrcode[nolinks]{\VAR[order.tse_qr_code_text|latex]}}
     \end{center}
 
 \end{document}


### PR DESCRIPTION
Test with https://kassen-qr-code-test.de/ was negative
Solution: invert colors. Now it works.