### PR TITLE
refactor(payout): added draft for payout runs

### DIFF
--- a/stustapay/core/__main__.py
+++ b/stustapay/core/__main__.py
@@ -24,7 +24,7 @@ def main():
     parser.add_subcommand("database", database.DatabaseManage)
     parser.add_subcommand("admin", admin.AdminCli)
     parser.add_subcommand("populate", populate.PopulateCli)
-    parser.add_subcommand("customer-bank-export", customer_bank_export.CustomerExportCli)
+    parser.add_subcommand("customer-bank-export", customer_bank_export.CustomerBankExport)
     ### / module registration
 
     loop = asyncio.new_event_loop()

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -23,9 +23,6 @@ from .service.auth import AuthService
 class CustomerExportCli(SubCommand):
     """
     Customer SEPA Export utility cli
-    Examples:
-        python -m stustapay.core -v customer-bank-export sepa -f sepa_transfer.xml
-        python -m stustapay.core -v customer-bank-export csv -f customer_bank_data.csv
     """
 
     SEPA_PATH = "sepa__run_{}__num_{}.xml"

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -20,9 +20,11 @@ from .config import Config
 from .service.auth import AuthService
 
 
-class CustomerExportCli(SubCommand):
+class CustomerBankExport(SubCommand):
     """
-    Customer SEPA Export utility cli
+    Customer SEPA Export utility CLI.
+
+    Use this to generate payouts for leftover customer balance.
     """
 
     SEPA_PATH = "sepa__run_{}__num_{}.xml"

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -26,6 +26,7 @@ class CustomerExportCli(SubCommand):
         python -m stustapay.core -v customer-bank-export sepa -f sepa_transfer.xml
         python -m stustapay.core -v customer-bank-export csv -f customer_bank_data.csv
     """
+
     SEPA_PATH = "sepa__run_{}__num_{}.xml"
     CSV_PATH = "bank_export__run_{}.csv"
 
@@ -80,14 +81,10 @@ class CustomerExportCli(SubCommand):
 
         async with db_pool.acquire() as conn:
             async with conn.transaction():
-                # payout_run_number = await database.get_payout_run_number(conn=conn)
-                # next_payout_run_number = await next_payout_run_number(conn=conn)
-                # number_of_customers = await get_number_of_customers(conn=conn)
-
                 if payout_run_id is None:
-                    payout_run_id, number_of_payouts = await create_payout_run(conn, created_by)                
+                    payout_run_id, number_of_payouts = await create_payout_run(conn, created_by)
                 else:
-                    number_of_payouts = await get_number_of_payouts(conn=conn, payout_run_id=payout_run_id) 
+                    number_of_payouts = await get_number_of_payouts(conn=conn, payout_run_id=payout_run_id)
 
                 if number_of_payouts == 0:
                     logging.warning("No customers with bank data found. Nothing to export.")
@@ -104,7 +101,10 @@ class CustomerExportCli(SubCommand):
                 # sepa export
                 for i in range(math.ceil(number_of_payouts / max_export_items_per_batch)):
                     customers_bank_data = await get_customer_bank_data(
-                        conn=conn, payout_run_id=payout_run_id, max_export_items_per_batch=max_export_items_per_batch, ith_batch=i
+                        conn=conn,
+                        payout_run_id=payout_run_id,
+                        max_export_items_per_batch=max_export_items_per_batch,
+                        ith_batch=i,
                     )
                     output_path = self.SEPA_PATH.format(payout_run_id, i + 1)
                     await sepa_export(
@@ -140,9 +140,9 @@ class CustomerExportCli(SubCommand):
         try:
             await database.check_revision_version(db_pool)
             execution_date = (
-                    datetime.datetime.strptime(self.args.execution_date, "%Y-%m-%d").date()
-                    if self.args.execution_date
-                    else None
+                datetime.datetime.strptime(self.args.execution_date, "%Y-%m-%d").date()
+                if self.args.execution_date
+                else None
             )
             await self._export_customer_bank_data(
                 db_pool=db_pool,

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -19,6 +19,13 @@ from . import database
 from .config import Config
 from .service.auth import AuthService
 
+# filename for the sepa transfer export,
+# can be batched into num_%d
+SEPA_PATH = "sepa__run_{}__num_{}.xml"
+
+# filename for the bank transfer csv overview
+CSV_PATH = "bank_export__run_{}.csv"
+
 
 class CustomerBankExport(SubCommand):
     """
@@ -26,9 +33,6 @@ class CustomerBankExport(SubCommand):
 
     Use this to generate payouts for leftover customer balance.
     """
-
-    SEPA_PATH = "sepa__run_{}__num_{}.xml"
-    CSV_PATH = "bank_export__run_{}.csv"
 
     def __init__(self, args, config: Config, **kwargs):
         del kwargs
@@ -58,7 +62,7 @@ class CustomerBankExport(SubCommand):
             "-d",
             "--dry-run",
             action="store_true",
-            help="Dry run. No database entry created.",
+            help="If set, don't perform any database modifications.",
         )
         subparser.add_argument(
             "-p",
@@ -75,76 +79,6 @@ class CustomerBankExport(SubCommand):
             help="Output path for the generated files. If not given, the current working directory is used.",
         )
 
-    async def _export_customer_bank_data(
-        self,
-        db_pool: asyncpg.Pool,
-        created_by: str,
-        execution_date: Optional[datetime.date] = None,
-        max_export_items_per_batch: Optional[int] = None,
-        dry_run: bool = False,
-        payout_run_id: Optional[int] = None,
-        output_path: str = "",
-    ):
-        execution_date = execution_date or datetime.date.today() + datetime.timedelta(days=2)
-
-        async with db_pool.acquire() as conn:
-            async with conn.transaction():
-                if payout_run_id is None:
-                    payout_run_id, number_of_payouts = await create_payout_run(conn, created_by)
-                else:
-                    number_of_payouts = await get_number_of_payouts(conn=conn, payout_run_id=payout_run_id)
-
-                if number_of_payouts == 0:
-                    logging.warning("No customers with bank data found. Nothing to export.")
-                    await conn.execute("rollback")
-                    return
-
-                max_export_items_per_batch = max_export_items_per_batch or number_of_payouts
-                cfg_srvc = ConfigService(
-                    db_pool=db_pool, config=self.config, auth_service=AuthService(db_pool=db_pool, config=self.config)
-                )
-                currency_ident = (await cfg_srvc.get_public_config(conn=conn)).currency_identifier
-                sepa_config = await cfg_srvc.get_sepa_config(conn=conn)
-
-                # sepa export
-                for i in range(math.ceil(number_of_payouts / max_export_items_per_batch)):
-                    customers_bank_data = await get_customer_bank_data(
-                        conn=conn,
-                        payout_run_id=payout_run_id,
-                        max_export_items_per_batch=max_export_items_per_batch,
-                        ith_batch=i,
-                    )
-                    file_path = os.path.join(output_path, self.SEPA_PATH.format(payout_run_id, i + 1))
-                    await sepa_export(
-                        customers_bank_data=customers_bank_data,
-                        output_path=file_path,
-                        sepa_config=sepa_config,
-                        currency_ident=currency_ident,
-                        execution_date=execution_date,
-                    )
-
-                # csv export
-                file_path = os.path.join(output_path, self.CSV_PATH.format(payout_run_id))
-                customers_bank_data = await get_customer_bank_data(
-                    conn=conn, payout_run_id=payout_run_id, max_export_items_per_batch=number_of_payouts
-                )
-                await csv_export(
-                    customers_bank_data=customers_bank_data,
-                    output_path=file_path,
-                    sepa_config=sepa_config,
-                    currency_ident=currency_ident,
-                    execution_date=execution_date,
-                )
-                if dry_run:
-                    # abort transaction
-                    await conn.execute("rollback")
-                    logging.warning("Dry run. No database entry created!")
-
-        logging.info(
-            f"Exported bank data of {number_of_payouts} customers into #{i + 1} files named "
-            f"{self.SEPA_PATH.format(payout_run_id, 'x')} and {self.CSV_PATH.format(payout_run_id)}"
-        )
-
     async def run(self):
         db_pool = await database.create_db_pool(self.config.database)
         try:
@@ -154,7 +88,8 @@ class CustomerBankExport(SubCommand):
                 if self.args.execution_date
                 else None
             )
-            await self._export_customer_bank_data(
+            await export_customer_payouts(
+                config=self.config,
                 db_pool=db_pool,
                 execution_date=execution_date,
                 created_by=self.args.created_by,
@@ -165,3 +100,74 @@ class CustomerBankExport(SubCommand):
             )
         finally:
             await db_pool.close()
+
+
+async def export_customer_payouts(
+    config: Config,
+    db_pool: asyncpg.Pool,
+    created_by: str,
+    execution_date: Optional[datetime.date] = None,
+    max_export_items_per_batch: Optional[int] = None,
+    dry_run: bool = False,
+    payout_run_id: Optional[int] = None,
+    output_path: str = "",
+):
+    execution_date = execution_date or datetime.date.today() + datetime.timedelta(days=2)
+
+    async with db_pool.acquire() as conn:
+        async with conn.transaction():
+            if payout_run_id is None:
+                payout_run_id, number_of_payouts = await create_payout_run(conn, created_by)
+            else:
+                number_of_payouts = await get_number_of_payouts(conn=conn, payout_run_id=payout_run_id)
+
+            if number_of_payouts == 0:
+                logging.warning("No customers with bank data found. Nothing to export.")
+                await conn.execute("rollback")
+                return
+
+            max_export_items_per_batch = max_export_items_per_batch or number_of_payouts
+            cfg_srvc = ConfigService(
+                db_pool=db_pool, config=config, auth_service=AuthService(db_pool=db_pool, config=config)
+            )
+            currency_ident = (await cfg_srvc.get_public_config(conn=conn)).currency_identifier
+            sepa_config = await cfg_srvc.get_sepa_config(conn=conn)
+
+            # sepa export
+            for i in range(math.ceil(number_of_payouts / max_export_items_per_batch)):
+                customers_bank_data = await get_customer_bank_data(
+                    conn=conn,
+                    payout_run_id=payout_run_id,
+                    max_export_items_per_batch=max_export_items_per_batch,
+                    ith_batch=i,
+                )
+                file_path = os.path.join(output_path, SEPA_PATH.format(payout_run_id, i + 1))
+                await sepa_export(
+                    customers_bank_data=customers_bank_data,
+                    output_path=file_path,
+                    sepa_config=sepa_config,
+                    currency_ident=currency_ident,
+                    execution_date=execution_date,
+                )
+
+            # csv export
+            file_path = os.path.join(output_path, CSV_PATH.format(payout_run_id))
+            customers_bank_data = await get_customer_bank_data(
+                conn=conn, payout_run_id=payout_run_id, max_export_items_per_batch=number_of_payouts
+            )
+            await csv_export(
+                customers_bank_data=customers_bank_data,
+                output_path=file_path,
+                sepa_config=sepa_config,
+                currency_ident=currency_ident,
+                execution_date=execution_date,
+            )
+            if dry_run:
+                # abort transaction
+                await conn.execute("rollback")
+                logging.warning("Dry run. No database entry created!")
+
+    logging.info(
+        f"Exported payouts of {number_of_payouts} customers into #{i + 1} files named "
+        f"{SEPA_PATH.format(payout_run_id, 'x')} and {CSV_PATH.format(payout_run_id)}"
+    )

--- a/stustapay/core/customer_bank_export.py
+++ b/stustapay/core/customer_bank_export.py
@@ -7,9 +7,10 @@ import asyncpg
 
 from stustapay.core.service.config import ConfigService
 from stustapay.core.service.customer.customer import (
+    create_payout_run,
     csv_export,
     get_customer_bank_data,
-    get_number_of_customers,
+    get_number_of_payouts,
     sepa_export,
 )
 from stustapay.core.subcommand import SubCommand
@@ -25,6 +26,8 @@ class CustomerExportCli(SubCommand):
         python -m stustapay.core -v customer-bank-export sepa -f sepa_transfer.xml
         python -m stustapay.core -v customer-bank-export csv -f customer_bank_data.csv
     """
+    SEPA_PATH = "sepa__run_{}__num_{}.xml"
+    CSV_PATH = "bank_export__run_{}.csv"
 
     def __init__(self, args, config: Config, **kwargs):
         del kwargs
@@ -34,14 +37,7 @@ class CustomerExportCli(SubCommand):
     @staticmethod
     def argparse_register(subparser):
         subparser.add_argument(
-            "action", choices=["sepa", "csv"], default="sepa", help="Choose between SEPA transfer file or CSV file."
-        )
-        subparser.add_argument(
-            "-f",
-            "--output-path",
-            default="customer_bank_data",
-            type=str,
-            help="Output path for export file without file extensions.",
+            "created_by", type=str, help="User who created the payout run. This is used for logging purposes."
         )
         subparser.add_argument(
             "-t",
@@ -57,77 +53,104 @@ class CustomerExportCli(SubCommand):
             type=int,
             help="Maximum amount of transactions per file. Not giving this argument means one large batch with all customers in a single file.",
         )
+        subparser.add_argument(
+            "-d",
+            "--dry-run",
+            action="store_true",
+            help="Dry run. No database entry created.",
+        )
+        subparser.add_argument(
+            "-p",
+            "--payout-run-id",
+            default=None,
+            type=int,
+            help="Payout run id. If not given, a new payout run is created. If given, the payout run is recreated.",
+        )
 
     async def _export_customer_bank_data(
         self,
         db_pool: asyncpg.Pool,
-        output_path: str,
+        created_by: str,
         execution_date: Optional[datetime.date] = None,
         max_export_items_per_batch: Optional[int] = None,
-        data_format: str = "sepa",
+        dry_run: bool = False,
+        payout_run_id: Optional[int] = None,
     ):
-        """
-        Supported data formats: sepa, csv
-        """
-        if data_format == "csv":
-            export_function = csv_export
-            file_extension = "csv"
-        elif data_format == "sepa":
-            export_function = sepa_export
-            file_extension = "xml"
-        else:
-            logging.error("Data format not supported!")
-            return
+        execution_date = execution_date or datetime.date.today() + datetime.timedelta(days=2)
 
         async with db_pool.acquire() as conn:
-            number_of_customers = await get_number_of_customers(conn=conn)
-            if number_of_customers == 0:
-                logging.info("No customers with bank data found. Nothing to export.")
+            async with conn.transaction():
+                # payout_run_number = await database.get_payout_run_number(conn=conn)
+                # next_payout_run_number = await next_payout_run_number(conn=conn)
+                # number_of_customers = await get_number_of_customers(conn=conn)
 
-            max_export_items_per_batch = max_export_items_per_batch or number_of_customers
+                if payout_run_id is None:
+                    payout_run_id, number_of_payouts = await create_payout_run(conn, created_by)                
+                else:
+                    number_of_payouts = await get_number_of_payouts(conn=conn, payout_run_id=payout_run_id) 
 
-            for i in range(math.ceil(number_of_customers / max_export_items_per_batch)):
-                # get all customer with iban not null
-                customers_bank_data = await get_customer_bank_data(
-                    conn=conn, max_export_items_per_batch=max_export_items_per_batch, ith_batch=i
-                )
+                if number_of_payouts == 0:
+                    logging.warning("No customers with bank data found. Nothing to export.")
+                    await conn.execute("rollback")
+                    return
 
+                max_export_items_per_batch = max_export_items_per_batch or number_of_payouts
                 cfg_srvc = ConfigService(
                     db_pool=db_pool, config=self.config, auth_service=AuthService(db_pool=db_pool, config=self.config)
                 )
                 currency_ident = (await cfg_srvc.get_public_config(conn=conn)).currency_identifier
                 sepa_config = await cfg_srvc.get_sepa_config(conn=conn)
 
-                output_path_file_extension = f"{output_path}_{i+1}.{file_extension}"
+                # sepa export
+                for i in range(math.ceil(number_of_payouts / max_export_items_per_batch)):
+                    customers_bank_data = await get_customer_bank_data(
+                        conn=conn, payout_run_id=payout_run_id, max_export_items_per_batch=max_export_items_per_batch, ith_batch=i
+                    )
+                    output_path = self.SEPA_PATH.format(payout_run_id, i + 1)
+                    await sepa_export(
+                        customers_bank_data=customers_bank_data,
+                        output_path=output_path,
+                        sepa_config=sepa_config,
+                        currency_ident=currency_ident,
+                        execution_date=execution_date,
+                    )
 
-                await export_function(
+                # csv export
+                output_path = self.CSV_PATH.format(payout_run_id)
+                customers_bank_data = await get_customer_bank_data(conn=conn, payout_run_id=payout_run_id)
+                await csv_export(
                     customers_bank_data=customers_bank_data,
-                    output_path=output_path_file_extension,
+                    output_path=output_path,
                     sepa_config=sepa_config,
                     currency_ident=currency_ident,
                     execution_date=execution_date,
                 )
+                if dry_run:
+                    # abort transaction
+                    await conn.execute("rollback")
+                    logging.warning("Dry run. No database entry created!")
 
         logging.info(
-            f"Exported bank data of {number_of_customers} customers into #{i + 1} files named {output_path}_x.{file_extension}"
+            f"Exported bank data of {number_of_payouts} customers into #{i + 1} files named "
+            f"{self.SEPA_PATH.format(payout_run_id, 'x')} and {self.CSV_PATH.format(payout_run_id)}"
         )
 
     async def run(self):
         db_pool = await database.create_db_pool(self.config.database)
         try:
             await database.check_revision_version(db_pool)
-            if self.args.action == "sepa":
-                execution_date = (
+            execution_date = (
                     datetime.datetime.strptime(self.args.execution_date, "%Y-%m-%d").date()
                     if self.args.execution_date
                     else None
-                )
-            # self.args.action is either sepa or csv
+            )
             await self._export_customer_bank_data(
                 db_pool=db_pool,
-                output_path=self.args.output_path,
                 execution_date=execution_date,
-                data_format=self.args.action,
+                created_by=self.args.created_by,
+                max_export_items_per_batch=self.args.max_transactions_batch,
+                dry_run=self.args.dry_run,
+                payout_run_id=self.args.payout_run_id,
             )
         finally:
             await db_pool.close()

--- a/stustapay/core/database.py
+++ b/stustapay/core/database.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 REVISION_VERSION_RE = re.compile(r"^-- revision: (?P<version>\w+)$")
 REVISION_REQUIRES_RE = re.compile(r"^-- requires: (?P<version>\w+)$")
 REVISION_TABLE = "schema_revision"
-CURRENT_REVISION = "dc0af35b"
+CURRENT_REVISION = "c5c4ae30"
 
 
 class DatabaseManage(subcommand.SubCommand):

--- a/stustapay/core/schema/customer.py
+++ b/stustapay/core/schema/customer.py
@@ -13,7 +13,7 @@ class Customer(Account):
     account_name: Optional[str]
     email: Optional[str]
     donation: Optional[float]
-    error: Optional[str]
+    payout_error: Optional[str]
     payout_run_id: Optional[int]
     payout_export: Optional[bool]
 

--- a/stustapay/core/schema/customer.py
+++ b/stustapay/core/schema/customer.py
@@ -15,6 +15,7 @@ class Customer(Account):
     donation: Optional[float]
     error: Optional[str]
     payout_run_id: Optional[int]
+    payout_export: Optional[bool]
 
 
 class OrderWithBon(Order):

--- a/stustapay/core/schema/customer.py
+++ b/stustapay/core/schema/customer.py
@@ -13,6 +13,8 @@ class Customer(Account):
     account_name: Optional[str]
     email: Optional[str]
     donation: Optional[float]
+    error: Optional[str]
+    payout_run_id: Optional[int]
 
 
 class OrderWithBon(Order):

--- a/stustapay/core/schema/db/0009-customer-donation.sql
+++ b/stustapay/core/schema/db/0009-customer-donation.sql
@@ -10,7 +10,5 @@ create or replace view customer as
     select
         a.*,
         customer_info.*
-    from
-        account_with_history a
-        left join customer_info
-            on (a.id = customer_info.customer_account_id);
+    from account_with_history a
+    left join customer_info on (a.id = customer_info.customer_account_id);

--- a/stustapay/core/schema/db/0010-payout-run.sql
+++ b/stustapay/core/schema/db/0010-payout-run.sql
@@ -1,0 +1,47 @@
+-- revision: c5c4ae30
+-- requires: dc0af35b
+
+
+create table if not exists payout_run (
+    id bigint primary key generated always as identity (start with 1),
+    created_by text not null unique
+    created_at timestamptz not null,
+);
+
+alter table customer_info add column payout_run_id bigint references payout_run(id) on delete cascade;
+alter table customer_info add column error text;
+alter table customer_info add column payout_export boolean default false not null;
+
+
+-- explicit customer view
+create or replace view customer as
+    select
+        a.*,
+        c.customer_account_id,
+        c.iban,
+        c.account_name,
+        c.email,
+        c.donation,
+        c.error,
+        c.payout_run_id
+    from account_with_history a
+    left join customer_info c on (a.id = c.customer_account_id);
+
+-- payout view: customers where payout already happened or is pending
+create or replace view payout as
+    select
+        c.customer_account_id,
+        c.iban,
+        c.account_name,
+        c.email,
+        c.user_tag_uid,
+        (c.balance - c.donation) as balance,
+        c.payout_run_id
+    from customer c
+    where
+        c.iban is not null and
+        round(c.balance, 2) > 0 and
+        round(c.balance - c.donation, 2) > 0 and
+        -- c.payout_run_id is null and
+        c.payout_export and
+        c.error is null;

--- a/stustapay/core/schema/db/0010-payout-run.sql
+++ b/stustapay/core/schema/db/0010-payout-run.sql
@@ -4,13 +4,13 @@
 
 create table if not exists payout_run (
     id bigint primary key generated always as identity (start with 1),
-    created_by text not null unique,
+    created_by text not null,
     created_at timestamptz not null
 );
 
 alter table customer_info add column payout_run_id bigint references payout_run(id) on delete cascade;
-alter table customer_info add column error text;
-alter table customer_info add column payout_export boolean default false not null;
+alter table customer_info add column payout_error text;
+alter table customer_info add column payout_export boolean default true not null;
 
 
 -- view needs to be recreated as it is not updated otherwise
@@ -36,6 +36,5 @@ create or replace view payout as
         c.iban is not null and
         round(c.balance, 2) > 0 and
         round(c.balance - c.donation, 2) > 0 and
-        -- c.payout_run_id is null and
         c.payout_export and
-        c.error is null;
+        c.payout_error is null;

--- a/stustapay/core/schema/db/0010-payout-run.sql
+++ b/stustapay/core/schema/db/0010-payout-run.sql
@@ -4,8 +4,8 @@
 
 create table if not exists payout_run (
     id bigint primary key generated always as identity (start with 1),
-    created_by text not null unique
-    created_at timestamptz not null,
+    created_by text not null unique,
+    created_at timestamptz not null
 );
 
 alter table customer_info add column payout_run_id bigint references payout_run(id) on delete cascade;
@@ -13,17 +13,11 @@ alter table customer_info add column error text;
 alter table customer_info add column payout_export boolean default false not null;
 
 
--- explicit customer view
+-- view needs to be recreated as it is not updated otherwise
 create or replace view customer as
     select
         a.*,
-        c.customer_account_id,
-        c.iban,
-        c.account_name,
-        c.email,
-        c.donation,
-        c.error,
-        c.payout_run_id
+        c.*
     from account_with_history a
     left join customer_info c on (a.id = c.customer_account_id);
 

--- a/stustapay/core/service/customer/customer.py
+++ b/stustapay/core/service/customer/customer.py
@@ -14,6 +14,7 @@ from sepaxml import SepaTransfer
 from stustapay.core.config import Config
 from stustapay.core.schema.config import PublicConfig, SEPAConfig
 from stustapay.core.schema.customer import Customer, OrderWithBon
+from stustapay.core.schema.user import format_user_tag_uid
 from stustapay.core.service.auth import AuthService, CustomerTokenMetadata
 from stustapay.core.service.common.dbservice import DBService
 from stustapay.core.service.common.decorators import (
@@ -105,7 +106,7 @@ async def csv_export(
                     customer.iban,
                     round(customer.balance, 2),
                     currency_ident,
-                    sepa_config.description.format(user_tag_uid=hex(customer.user_tag_uid)),
+                    sepa_config.description.format(user_tag_uid=format_user_tag_uid(customer.user_tag_uid)),
                     execution_date.isoformat(),
                     customer.user_tag_uid,
                     customer.email,
@@ -146,7 +147,7 @@ async def sepa_export(
             "BIC": str(IBAN(customer.iban).bic),
             "amount": round(customer.balance * 100),  # in cents
             "execution_date": execution_date,
-            "description": sepa_config.description.format(user_tag_uid=hex(customer.user_tag_uid)),
+            "description": sepa_config.description.format(user_tag_uid=format_user_tag_uid(customer.user_tag_uid)),
         }
 
         if not re.match(r"^[a-zA-Z0-9 \-.,:()/?'+]*$", payment["description"]):  # type: ignore

--- a/stustapay/core/service/customer/customer.py
+++ b/stustapay/core/service/customer/customer.py
@@ -96,7 +96,7 @@ async def csv_export(
     with open(output_path, "w") as f:
         execution_date = execution_date or datetime.date.today() + datetime.timedelta(days=2)
         writer = csv.writer(f)
-        fields = ["beneficiary_name", "iban", "amount", "currency", "reference", "execution_date"]
+        fields = ["beneficiary_name", "iban", "amount", "currency", "reference", "execution_date", "uid", "email"]
         writer.writerow(fields)
         for customer in customers_bank_data:
             writer.writerow(
@@ -107,6 +107,8 @@ async def csv_export(
                     currency_ident,
                     sepa_config.description.format(user_tag_uid=hex(customer.user_tag_uid)),
                     execution_date.isoformat(),
+                    customer.user_tag_uid,
+                    customer.email,
                 ]
             )
 

--- a/stustapay/core/service/customer/customer.py
+++ b/stustapay/core/service/customer/customer.py
@@ -54,7 +54,9 @@ class CustomerBank(BaseModel):
     donation: float = 0.0
 
 
-async def get_number_of_payouts(conn: asyncpg.Connection, payout_run_id: int) -> int:
+async def get_number_of_payouts(conn: asyncpg.Connection, payout_run_id: Optional[int]) -> int:
+    if payout_run_id is None:
+        return await conn.fetchval("select count(*) from payout where payout_run_id is null")
     return await conn.fetchval("select count(*) from payout where payout_run_id = $1", payout_run_id)
 
 
@@ -76,7 +78,7 @@ async def get_customer_bank_data(
     conn: asyncpg.Connection, payout_run_id: int, max_export_items_per_batch: int, ith_batch: int = 0
 ) -> list[Payout]:
     rows = await conn.fetch(
-        "select * from payout where payout_run_id = $1 limit $2 offset $3",
+        "select * from payout where payout_run_id = $1 order by user_tag_uid asc limit $2 offset $3",
         payout_run_id,
         max_export_items_per_batch,
         ith_batch * max_export_items_per_batch,

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -183,8 +183,6 @@ class CustomerServiceTest(TerminalTestCase):
         result = await get_number_of_payouts(self.db_conn, None)
         self.assertEqual(result, len(self.customers_to_transfer))
 
-    # TODO: test create payouts
-
     async def test_get_customer_bank_data(self):
         def check_data(result: list[Payout], leng: int, ith: int = 0) -> None:
             self.assertEqual(len(result), leng)

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -617,6 +617,18 @@ class CustomerServiceTest(TerminalTestCase):
             else:
                 self.assertIsNone(customer.payout_run_id)
 
+        # test customer "Rolf1" can no longer be updated since they now have a payout run assigned
+        auth = await self.customer_service.login_customer(uid=(12345 * (1 + 1)), pin="pin1")
+        self.assertIsNotNone(auth)
+        customer_bank = CustomerBank(
+            iban="DE89370400440532013000", account_name="Rolf1 updated", email="lol@rolf.de", donation=2.0
+        )
+        with self.assertRaises(InvalidArgument):
+            await self.customer_service.update_customer_info(
+                token=auth.token,
+                customer_bank=customer_bank,
+            )
+
     async def test_payout_runs(self):
         output_path = os.path.join(self.tmp_dir, "test_payout_runs")
         os.makedirs(output_path, exist_ok=True)

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -12,6 +12,7 @@ from stustapay.core.customer_bank_export import CustomerExportCli
 from stustapay.core.schema.customer import Customer
 from stustapay.core.schema.order import Order, OrderType, PaymentMethod
 from stustapay.core.schema.product import NewProduct
+from stustapay.core.schema.user import format_user_tag_uid
 from stustapay.core.service.common.error import InvalidArgument, Unauthorized, AccessDenied
 from stustapay.core.service.config import ConfigService
 from stustapay.core.service.customer.customer import (
@@ -220,7 +221,7 @@ class CustomerServiceTest(TerminalTestCase):
             # check description
             self.assertEqual(
                 tree.find(f"{p}CstmrCdtTrfInitn/{p}PmtInf/{p}CdtTrfTxInf[{i+1}]/{p}RmtInf/{p}Ustrd").text,
-                self.sepa_config.description.format(user_tag_uid=hex(customer["uid"])),
+                self.sepa_config.description.format(user_tag_uid=format_user_tag_uid(customer["uid"])),
             )
 
         self.assertEqual(total_sum, group_sum)
@@ -292,7 +293,7 @@ class CustomerServiceTest(TerminalTestCase):
                 self.assertEqual(row["currency"], self.currency_ident)
                 self.assertEqual(
                     row["reference"],
-                    self.sepa_config.description.format(user_tag_uid=hex(customer["uid"])),
+                    self.sepa_config.description.format(user_tag_uid=format_user_tag_uid(customer["uid"])),
                 )
                 self.assertEqual(row["execution_date"], execution_date.isoformat())
                 self.assertEqual(row["email"], customer["email"])

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -248,6 +248,11 @@ class CustomerServiceTest(TerminalTestCase):
         payout_run_id, number_of_payouts = await create_payout_run(self.db_conn, "Test")
         self.assertEqual(number_of_payouts, len(self.customers_to_transfer))
 
+        self.assertEqual(
+            number_of_payouts,
+            await self.db_conn.fetchval("select count(*) from payout where payout_run_id = $1", payout_run_id),
+        )
+
         result = await get_customer_bank_data(self.db_conn, payout_run_id, len(self.customers_to_transfer))
         check_data(result, len(self.customers_to_transfer))
 

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -8,7 +8,7 @@ import unittest
 from dateutil.parser import parse
 
 from stustapay.core.config import CustomerPortalApiConfig
-from stustapay.core.customer_bank_export import CustomerExportCli
+from stustapay.core.customer_bank_export import CustomerBankExport
 from stustapay.core.schema.customer import Customer
 from stustapay.core.schema.order import Order, OrderType, PaymentMethod
 from stustapay.core.schema.product import NewProduct
@@ -548,7 +548,7 @@ class CustomerServiceTest(TerminalTestCase):
         self.assertEqual(result.about_page_url, cpc.about_page_url)
 
     async def test_export_customer_bank_data(self):
-        cli = CustomerExportCli(None, config=self.test_config)
+        cli = CustomerBankExport(None, config=self.test_config)
         output_path = os.path.join(self.tmp_dir, "test_export")
         os.makedirs(output_path, exist_ok=True)
 
@@ -600,7 +600,7 @@ class CustomerServiceTest(TerminalTestCase):
                 self.assertIsNone(customer.payout_run_id)
 
     async def test_payout_runs(self):
-        cli = CustomerExportCli(None, config=self.test_config)
+        cli = CustomerBankExport(None, config=self.test_config)
         output_path = os.path.join(self.tmp_dir, "test_payout_runs")
         os.makedirs(output_path, exist_ok=True)
 

--- a/stustapay/tests/test_customer_service.py
+++ b/stustapay/tests/test_customer_service.py
@@ -295,6 +295,8 @@ class CustomerServiceTest(TerminalTestCase):
                     self.sepa_config.description.format(user_tag_uid=hex(customer["uid"])),
                 )
                 self.assertEqual(row["execution_date"], execution_date.isoformat())
+                self.assertEqual(row["email"], customer["email"])
+                self.assertEqual(int(row["uid"]), customer["uid"])
                 export_sum += float(row["amount"])
 
         sql_sum = float(await self.db_conn.fetchval("select sum(round(balance, 2)) from payout"))

--- a/web/apps/customer-portal/src/api/customerApi.ts
+++ b/web/apps/customer-portal/src/api/customerApi.ts
@@ -1,6 +1,15 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { customerApiBaseQuery } from "./common";
 import { Customer, CustomerInfo, OrderWithBon } from "@stustapay/models";
+import { z } from "zod";
+
+export const CustomerBankSchema = z.object({
+  iban: z.string(),
+  account_name: z.string(),
+  email: z.string(),
+  donation: z.number(),
+});
+export type CustomerBank = z.infer<typeof CustomerBankSchema>;
 
 export const customerApi = createApi({
   reducerPath: "customerApi",
@@ -20,7 +29,7 @@ export const customerApi = createApi({
       providesTags: (result) => ["order"],
     }),
 
-    setCustomerInfo: builder.mutation<void, CustomerInfo>({
+    setCustomerInfo: builder.mutation<void, CustomerBank>({
       query: (customer) => ({
         url: "/customer_info",
         method: "POST",

--- a/web/libs/models/src/lib/customer.ts
+++ b/web/libs/models/src/lib/customer.ts
@@ -3,10 +3,12 @@ import { AccountSchema } from "./account";
 import { OrderSchema } from "./order";
 
 export const CustomerInfoSchema = z.object({
-  iban: z.string(),
-  account_name: z.string(),
-  email: z.string(),
-  donation: z.number(),
+  iban: z.string().nullable(),
+  account_name: z.string().nullable(),
+  email: z.string().nullable(),
+  donation: z.number().nullable(),
+  error: z.string().nullable(),
+  payout_run_id: z.number().nullable(),
 });
 
 export type CustomerInfo = z.infer<typeof CustomerInfoSchema>;

--- a/web/libs/models/src/lib/customer.ts
+++ b/web/libs/models/src/lib/customer.ts
@@ -9,6 +9,7 @@ export const CustomerInfoSchema = z.object({
   donation: z.number().nullable(),
   error: z.string().nullable(),
   payout_run_id: z.number().nullable(),
+  payout_export: z.boolean().nullable(),
 });
 
 export type CustomerInfo = z.infer<typeof CustomerInfoSchema>;

--- a/web/libs/models/src/lib/customer.ts
+++ b/web/libs/models/src/lib/customer.ts
@@ -7,7 +7,7 @@ export const CustomerInfoSchema = z.object({
   account_name: z.string().nullable(),
   email: z.string().nullable(),
   donation: z.number().nullable(),
-  error: z.string().nullable(),
+  payout_error: z.string().nullable(),
   payout_run_id: z.number().nullable(),
   payout_export: z.boolean().nullable(),
 });


### PR DESCRIPTION
This PR adds the possibility to incrementally export SPEA payout data. For each export a payout_run is created in the db which avoids reexporting already exported customers. Furthermore, a payout_export flag in the customer_info relation can be used to avoid exporting specific customers.